### PR TITLE
Cross section function

### DIFF
--- a/sample/postproc_tester.py
+++ b/sample/postproc_tester.py
@@ -1,0 +1,35 @@
+#MUST BE INCLUDED TO WORK
+import sys
+sys.path.insert(0,r"/home/helmi/Open3D-ML_PRISM/") #directory to the root project
+
+from utils import CustomDataLoader,PostProcess
+import open3d.ml.torch as ml3d
+import open3d.ml as _ml3d
+import os
+import numpy as np
+
+def main():
+    #play around with the start and end
+    Start = [-1,5,0.3]
+    End = [100,40,2]
+    tol = 0.1 #Huge tolerance of 0.5m for each side of the line
+    
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    file_path = os.path.join(dir_path,"sample_Data.npy")
+    sliced_path = os.path.join(dir_path,"Sliced_points.npy")
+    cfg_directory = os.path.expanduser("~/Open3D-ML_PRISM/ml3d/configs/")
+    cfg_file = os.path.join(cfg_directory, "randlanet_parislille3d.yml")
+    cfg = _ml3d.utils.Config.load_from_file(cfg_file)
+    
+    Data = np.load(file_path)
+    cross_sec = PostProcess()
+    cross_sec.pc_slice(Start,End,tol,Data,"XY") #try to change the plane orientation XY,XZ,YZ
+    Xsec_data = np.load(sliced_path)
+    print(f"Length of sliced data: {len(Xsec_data)}")
+    
+    Visualize = CustomDataLoader(cfg)
+    Visualize.VisualizingData(sliced_path)
+    
+    
+if __name__ == "__main__":
+    main()

--- a/sample/postproc_tester.py
+++ b/sample/postproc_tester.py
@@ -10,7 +10,7 @@ import numpy as np
 
 def main():
     #play around with the start and end
-    Start = [-1,5,0.3]
+    Start = [-50,5,0.3]
     End = [100,40,2]
     tol = 0.1 #Huge tolerance of 0.5m for each side of the line
     
@@ -24,8 +24,7 @@ def main():
     Data = np.load(file_path)
     cross_sec = PostProcess()
     cross_sec.pc_slice(Start,End,tol,Data,"XY") #try to change the plane orientation XY,XZ,YZ
-    Xsec_data = np.load(sliced_path)
-    print(f"Length of sliced data: {len(Xsec_data)}")
+    
     
     Visualize = CustomDataLoader(cfg)
     Visualize.VisualizingData(sliced_path)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,4 @@
 from .custom_load import CustomDataLoader
+from .postprocess import PostProcess
 
-__all__ = ["CustomDataLoader"]
+__all__ = ["CustomDataLoader","PostProcess"]

--- a/utils/postprocess.py
+++ b/utils/postprocess.py
@@ -16,6 +16,9 @@ class PostProcess():
         
         #change and res would refer to the manipulated and responding variables
         #which vary depending on the chosen plane
+        print(f"\nDomain range of X-axis: [{min(result[:,0])} {max(result[:,0])}]")
+        print(f"Domain range of Y-axis: [{min(result[:,1])} {max(result[:,1])}]")
+        print(f"Domain range of Z-axis: [{min(result[:,2])} {max(result[:,2])}]")
         
         change_ind, res_ind = self.planar_axes(plane)
         top_dif = End[res_ind] - Start[res_ind]

--- a/utils/postprocess.py
+++ b/utils/postprocess.py
@@ -1,0 +1,103 @@
+import numpy as np
+import os
+import sys
+import math
+from typing import Literal
+
+class PostProcess():
+    def __init__(self) -> None:
+        
+        main_path = os.path.abspath(sys.argv[0])
+        self.dir = os.path.dirname(os.path.abspath(main_path))
+        self.file_path = os.path.join(self.dir, "Sliced_points.npy")
+    
+    def pc_slice(self,Start,End,tolerance,result,plane: Literal['XY', 'XZ', 'YZ'] = 'XY'):
+        #Straight line function of y = mx + c
+        
+        #change and res would refer to the manipulated and responding variables
+        #which vary depending on the chosen plane
+        
+        change_ind, res_ind = self.planar_axes(plane)
+        top_dif = End[res_ind] - Start[res_ind]
+        bottom_dif = End[change_ind] - Start[change_ind]
+        sample_points = result[:,change_ind]
+        
+        if bottom_dif == 0: #When straight line is vertical
+            prop = [Start[change_ind]]
+        else:
+            m = top_dif/bottom_dif
+            c = End[res_ind] - m*End[change_ind]
+            prop = [m,c]
+        
+        benchmark = self.tolerance_limit(prop,tolerance)
+        print(f"Benchmark value: {benchmark}") #should return a single value
+        
+        #when straight line is not vertical
+        if bottom_dif != 0:
+            
+            res_points = self.create_line(m,c,sample_points)
+            vertical_dif = abs(result[:,res_ind] - res_points)
+            index = np.asarray(benchmark>vertical_dif).nonzero()
+            sliced_points = result[index]
+                        
+            #Filtering the points based on the length of the drawn line
+            change_condition = np.logical_and(Start[change_ind] < sliced_points[:,change_ind],End[change_ind] > sliced_points[:,change_ind])
+            index_change = np.asarray(change_condition).nonzero()
+            change_lim_pc = sliced_points[index_change]
+            res_condition = np.logical_and(Start[res_ind] < change_lim_pc[:,res_ind],End[res_ind] > change_lim_pc[:,res_ind])
+            index_res = np.asarray(res_condition).nonzero()
+            sliced_points = change_lim_pc[index_res]
+        else:
+            pass #gonna do it later    
+        
+        
+        return np.save(self.file_path,sliced_points)
+        
+    def tolerance_limit(self,prop,tolerance): 
+        #tolerance is defined as the perpendicular distance from an imaginary offset line to the created line
+        
+        if len(prop) == 1: #for vertical straight line
+            compare = tolerance
+        else:
+            m = abs(prop[0]) #converting the value to be absolute
+            slope = math.atan(m) #slope angle of the line in rads
+            vertical_dist = tolerance/ math.cos(slope) #vertical distance of original line 
+            #to the offset line using the same x coordinate value (changing variable)   
+            compare = vertical_dist
+            
+        return compare  
+    
+    
+    def planar_axes(self,plane):
+        #return index of the two axes that make up the plane
+        #array is expected to be in [x,y,z] orientation
+        #index is based on manipulated(change) and responding(res) variables
+        
+        if plane == 'XY': #plan view
+            change_ind = 0 #X
+            res_ind = 1 #Y
+       
+        elif plane == 'XZ': #front view
+            change_ind = 0 #X
+            res_ind = 2    #Z
+        
+        elif plane == 'YZ': #side view
+            change_ind = 1 #Y
+            res_ind = 2 #Z
+        else:
+            print('\nError: Plane is not correctly define')
+            quit()
+                
+        return change_ind, res_ind
+    
+    
+    def create_line(self,m,c,sample_points):
+                
+        res_points = m*sample_points + c
+               
+        return res_points     
+        
+        
+        
+        
+

--- a/utils/postprocess.py
+++ b/utils/postprocess.py
@@ -44,12 +44,16 @@ class PostProcess():
             sliced_points = result[index]
                         
             #Filtering the points based on the length of the drawn line
-            change_condition = np.logical_and(Start[change_ind] < sliced_points[:,change_ind],End[change_ind] > sliced_points[:,change_ind])
-            index_change = np.asarray(change_condition).nonzero()
-            change_lim_pc = sliced_points[index_change]
-            res_condition = np.logical_and(Start[res_ind] < change_lim_pc[:,res_ind],End[res_ind] > change_lim_pc[:,res_ind])
-            index_res = np.asarray(res_condition).nonzero()
-            sliced_points = change_lim_pc[index_res]
+            
+            if m < 100000: #threshold when the difference between changing values is approaching to 0
+                change_condition = np.logical_and(Start[change_ind] < sliced_points[:,change_ind],End[change_ind] > sliced_points[:,change_ind])
+                index_change = np.asarray(change_condition).nonzero()
+                sliced_points = sliced_points[index_change]
+            
+            if m > 0.11: #threshold when the difference between responding values is approaching to 0
+                res_condition = np.logical_and(Start[res_ind] < sliced_points[:,res_ind],End[res_ind] > sliced_points[:,res_ind])
+                index_res = np.asarray(res_condition).nonzero()
+                sliced_points = sliced_points[index_res]
         else:
             pass #gonna do it later    
         

--- a/utils/testing.py
+++ b/utils/testing.py
@@ -59,16 +59,14 @@ def main():
     #las_path = r"/home/jeevin/Open3D-ML_PRISM/utils/LOT_BUNGALOW.las"
     #las_path = r"/mnt/c/Users/zulhe/OneDrive/Documents/LOT BUNGALOW/LOT_BUNGALOW.las"
     
-    Start = [-6000.325,-7900.45,50.32]
-    End = [-5800.125,-7901,60.27]
-    tol = 0.1 #Huge tolerance of 0.5m for each side of the line
+    Start = [-5950,-7900.45,50.32]
+    End = [-5950.05,-7870,60.27]
+    tol = 0.05
     
     Data = np.load(file_path)
     cross_sec = PostProcess()
-    cross_sec.pc_slice(Start,End,tol,Data,"XY") #try to change the plane orientation XY,XZ,YZ
-    Xsec_data = np.load(sliced_path)
-    print(f"Length of sliced data: {len(Xsec_data)}")
-      
+    cross_sec.pc_slice(Start,End,tol,Data,"XZ") #try to change the plane orientation XY,XZ,YZ
+       
     testing = CustomDataLoader(cfg=cfg) 
     testing.VisualizingData(sliced_path)
 
@@ -87,13 +85,6 @@ def main():
     # saved per file. Currently set at 1,100,000 points per file or 19 batches per file.
 
     # results = testing.load_data(ext='pkl')
-     
-    # with open ('results.pkl', 'wb') as f:
-    #     pickle.dump(results, f)
-    
-    # with open ('results.pkl', 'rb') as f:
-    #     results = pickle.load(f)
-
     # testing.SavetoLas(results)
     #testing.SavetoPkl(results,Dict_num=19)
        

--- a/utils/testing.py
+++ b/utils/testing.py
@@ -1,8 +1,10 @@
 from custom_load import CustomDataLoader
+from postprocess import PostProcess
 import os
 import open3d.ml as _ml3d
 import open3d.ml.torch as ml3d
 import pickle
+import numpy as np
 
 
 ####################################
@@ -46,13 +48,29 @@ import pickle
 
 def main():
     #Initializing directory paths
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    sliced_path = os.path.join(dir_path,"Sliced_points.npy")
+    file_path = os.path.join(dir_path,"utils_Data.npy")
+    
     cfg_directory = os.path.expanduser("~/Open3D-ML_PRISM/ml3d/configs/")
     cfg_file = os.path.join(cfg_directory, "randlanet_parislille3d.yml")
     cfg = _ml3d.utils.Config.load_from_file(cfg_file)
     cfg.model['in_channels'] = 3 #3 for models without colours and 6 for models with colours
     #las_path = r"/home/jeevin/Open3D-ML_PRISM/utils/LOT_BUNGALOW.las"
-    las_path = r"/mnt/c/Users/zulhe/OneDrive/Documents/LOT BUNGALOW/LOT_BUNGALOW.las"
-    testing = CustomDataLoader(cfg = cfg) 
+    #las_path = r"/mnt/c/Users/zulhe/OneDrive/Documents/LOT BUNGALOW/LOT_BUNGALOW.las"
+    
+    Start = [-6000,-7900,50]
+    End = [-5800,-7800,60]
+    tol = 0.1 #Huge tolerance of 0.5m for each side of the line
+    
+    Data = np.load(file_path)
+    cross_sec = PostProcess()
+    cross_sec.pc_slice(Start,End,tol,Data,"XZ") #try to change the plane orientation XY,XZ,YZ
+    Xsec_data = np.load(sliced_path)
+    print(f"Length of sliced data: {len(Xsec_data)}")
+      
+    testing = CustomDataLoader(cfg=cfg) 
+    testing.VisualizingData(sliced_path)
 
    
     #testing.VisualizingData() #To visualize raw data prior to inference
@@ -68,7 +86,7 @@ def main():
     # testing.SavetoPkl(Results,Dict_num=19) #(Optional) Provide a threshold of the maximum number of points
     # saved per file. Currently set at 1,100,000 points per file or 19 batches per file.
 
-    results = testing.load_data(ext='pkl')
+    # results = testing.load_data(ext='pkl')
      
     # with open ('results.pkl', 'wb') as f:
     #     pickle.dump(results, f)
@@ -76,7 +94,7 @@ def main():
     # with open ('results.pkl', 'rb') as f:
     #     results = pickle.load(f)
 
-    testing.SavetoLas(results)
+    # testing.SavetoLas(results)
     #testing.SavetoPkl(results,Dict_num=19)
        
 

--- a/utils/testing.py
+++ b/utils/testing.py
@@ -59,13 +59,13 @@ def main():
     #las_path = r"/home/jeevin/Open3D-ML_PRISM/utils/LOT_BUNGALOW.las"
     #las_path = r"/mnt/c/Users/zulhe/OneDrive/Documents/LOT BUNGALOW/LOT_BUNGALOW.las"
     
-    Start = [-6000,-7900,50]
-    End = [-5800,-7800,60]
+    Start = [-6000.325,-7900.45,50.32]
+    End = [-5800.125,-7901,60.27]
     tol = 0.1 #Huge tolerance of 0.5m for each side of the line
     
     Data = np.load(file_path)
     cross_sec = PostProcess()
-    cross_sec.pc_slice(Start,End,tol,Data,"XZ") #try to change the plane orientation XY,XZ,YZ
+    cross_sec.pc_slice(Start,End,tol,Data,"XY") #try to change the plane orientation XY,XZ,YZ
     Xsec_data = np.load(sliced_path)
     print(f"Length of sliced data: {len(Xsec_data)}")
       


### PR DESCRIPTION
	modified:   utils/__init__.py
	new file:   utils/postprocess.py

I created a new class PostProcess in the utils folder. The function can plot cross-sectional area depending on where the line is drawn. postproc_tester.py script has been made in the sample folder to test out the new class. The cross-sectional area will be limited to the length of the line drawn. It can also be viewed in three planar surfaces of 'XY', 'XZ' and 'YZ'. Try and play around with that as well as the coordinate of End and Start which makes up the drawn line to see how it works. Tolerance is added to include nearby points within a specified threshold. The class is not fully done yet as there is still one more condition that needs to be coded up to fulfill all possibilities of a drawn line.